### PR TITLE
Fix Travis-CI

### DIFF
--- a/scripts/docker/postgres/Dockerfile
+++ b/scripts/docker/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:10 AS fdwPostgres
+FROM postgres:10.10 AS fdwPostgres
 
 ENV POSTGRES_USER postgres
 ENV POSTGRES_PASSWORD postgres
@@ -10,14 +10,18 @@ COPY . /neo4j-fdw/source
 RUN apt-get update \
       && apt-get install -y --no-install-recommends \
            build-essential \
-           postgresql-server-dev-10 \
            python-dev \
            python-setuptools \
            python-dev \
            python-pip \
-           postgresql-plpython-10 \
            git \
+           wget \
       && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /tmp/pgdebs
+RUN wget --quiet -P /tmp/pgdebs https://atalia.postgresql.org/morgue/p/postgresql-10/postgresql-server-dev-10_10.10-1.pgdg90%2B1_amd64.deb https://atalia.postgresql.org/morgue/p/postgresql-10/postgresql-plpython-10_10.10-1.pgdg90%2B1_amd64.deb https://atalia.postgresql.org/morgue/p/postgresql-10/libpq5_10.10-1.pgdg90%2B1_amd64.deb https://atalia.postgresql.org/morgue/p/postgresql-10/libpq-dev_10.10-1.pgdg90%2B1_amd64.deb
+RUN apt install -y --allow-downgrades /tmp/pgdebs/postgresql-server-dev-10_10.10-1.pgdg90+1_amd64.deb /tmp/pgdebs/postgresql-plpython-10_10.10-1.pgdg90+1_amd64.deb /tmp/pgdebs/libpq5_10.10-1.pgdg90+1_amd64.deb /tmp/pgdebs/libpq-dev_10.10-1.pgdg90+1_amd64.deb
+RUN rm -r /tmp/pgdebs
 
 RUN ["chmod", "+x", "/neo4j-fdw/source/scripts/docker/postgres/init.sh"]
 RUN /neo4j-fdw/source/scripts/docker/postgres/init.sh


### PR DESCRIPTION
Change from generic postgres:10 docker image to last specific version using python2.7
Then install corresponding postgresql-server-dev-10, postgresql-plpython-10 packages plus dependencies libpq5, and libpq-dev from postgresql.org archives