### PR TITLE
Fix Travis-CI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   # Neo4j service
   neo4j:
-    image: neo4j:enterprise
+    image: neo4j:3.5.14-enterprise
     ports:
       - "7474:7474"
       - "7687:7687"

--- a/scripts/docker/neo4j/init.sh
+++ b/scripts/docker/neo4j/init.sh
@@ -4,4 +4,4 @@
 echo "~~~"
 echo "~ Init database"
 echo "~~~"
-su-exec neo4j bin/cypher-shell -u neo4j -p admin < /source/scripts/docker/neo4j/initdb.gql
+su neo4j -s /bin/bash -c "bin/cypher-shell -u neo4j -p admin < /source/scripts/docker/neo4j/initdb.gql"

--- a/scripts/docker/postgres/Dockerfile
+++ b/scripts/docker/postgres/Dockerfile
@@ -15,9 +15,11 @@ RUN apt-get update \
            python-dev \
            python-pip \
            git \
+           libfaketime \
            wget \
       && rm -rf /var/lib/apt/lists/*
 
+RUN cp /neo4j-fdw/source/scripts/faketime.sh /docker-entrypoint-initdb.d/
 
 RUN mkdir /tmp/pgdebs
 RUN wget --quiet -P /tmp/pgdebs https://atalia.postgresql.org/morgue/p/postgresql-10/postgresql-server-dev-10_10.10-1.pgdg90%2B1_amd64.deb https://atalia.postgresql.org/morgue/p/postgresql-10/postgresql-plpython-10_10.10-1.pgdg90%2B1_amd64.deb https://atalia.postgresql.org/morgue/p/postgresql-10/libpq5_10.10-1.pgdg90%2B1_amd64.deb https://atalia.postgresql.org/morgue/p/postgresql-10/libpq-dev_10.10-1.pgdg90%2B1_amd64.deb

--- a/scripts/docker/postgres/Dockerfile
+++ b/scripts/docker/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:10 AS fdwPostgres
+FROM postgres:10.10 AS fdwPostgres
 
 ENV POSTGRES_USER postgres
 ENV POSTGRES_PASSWORD postgres
@@ -10,16 +10,19 @@ COPY . /neo4j-fdw/source
 RUN apt-get update \
       && apt-get install -y --no-install-recommends \
            build-essential \
-           postgresql-server-dev-10 \
            python-dev \
            python-setuptools \
            python-dev \
            python-pip \
-           postgresql-plpython-10 \
            git \
+           wget \
       && rm -rf /var/lib/apt/lists/*
+
+
+RUN mkdir /tmp/pgdebs
+RUN wget --quiet -P /tmp/pgdebs https://atalia.postgresql.org/morgue/p/postgresql-10/postgresql-server-dev-10_10.10-1.pgdg90%2B1_amd64.deb https://atalia.postgresql.org/morgue/p/postgresql-10/postgresql-plpython-10_10.10-1.pgdg90%2B1_amd64.deb https://atalia.postgresql.org/morgue/p/postgresql-10/libpq5_10.10-1.pgdg90%2B1_amd64.deb https://atalia.postgresql.org/morgue/p/postgresql-10/libpq-dev_10.10-1.pgdg90%2B1_amd64.deb
+RUN apt install -y --allow-downgrades /tmp/pgdebs/postgresql-server-dev-10_10.10-1.pgdg90+1_amd64.deb /tmp/pgdebs/postgresql-plpython-10_10.10-1.pgdg90+1_amd64.deb /tmp/pgdebs/libpq5_10.10-1.pgdg90+1_amd64.deb /tmp/pgdebs/libpq-dev_10.10-1.pgdg90+1_amd64.deb
+RUN rm -r /tmp/pgdebs
 
 RUN ["chmod", "+x", "/neo4j-fdw/source/scripts/docker/postgres/init.sh"]
 RUN /neo4j-fdw/source/scripts/docker/postgres/init.sh
-
-

--- a/scripts/docker/postgres/Dockerfile
+++ b/scripts/docker/postgres/Dockerfile
@@ -21,9 +21,17 @@ RUN apt-get update \
 
 RUN cp /neo4j-fdw/source/scripts/faketime.sh /docker-entrypoint-initdb.d/
 
-RUN mkdir /tmp/pgdebs
-RUN wget --quiet -P /tmp/pgdebs https://atalia.postgresql.org/morgue/p/postgresql-10/postgresql-server-dev-10_10.10-1.pgdg90%2B1_amd64.deb https://atalia.postgresql.org/morgue/p/postgresql-10/postgresql-plpython-10_10.10-1.pgdg90%2B1_amd64.deb https://atalia.postgresql.org/morgue/p/postgresql-10/libpq5_10.10-1.pgdg90%2B1_amd64.deb https://atalia.postgresql.org/morgue/p/postgresql-10/libpq-dev_10.10-1.pgdg90%2B1_amd64.deb
-RUN apt install -y --allow-downgrades /tmp/pgdebs/postgresql-server-dev-10_10.10-1.pgdg90+1_amd64.deb /tmp/pgdebs/postgresql-plpython-10_10.10-1.pgdg90+1_amd64.deb /tmp/pgdebs/libpq5_10.10-1.pgdg90+1_amd64.deb /tmp/pgdebs/libpq-dev_10.10-1.pgdg90+1_amd64.deb
+RUN mkdir /tmp/pgdebs \
+      && wget --quiet -P /tmp/pgdebs \
+              https://atalia.postgresql.org/morgue/p/postgresql-10/postgresql-server-dev-10_10.10-1.pgdg90%2B1_amd64.deb \
+              https://atalia.postgresql.org/morgue/p/postgresql-10/postgresql-plpython-10_10.10-1.pgdg90%2B1_amd64.deb \
+              https://atalia.postgresql.org/morgue/p/postgresql-10/libpq5_10.10-1.pgdg90%2B1_amd64.deb \
+              https://atalia.postgresql.org/morgue/p/postgresql-10/libpq-dev_10.10-1.pgdg90%2B1_amd64.deb \
+      && apt install -y --allow-downgrades \
+              /tmp/pgdebs/postgresql-server-dev-10_10.10-1.pgdg90+1_amd64.deb \
+              /tmp/pgdebs/postgresql-plpython-10_10.10-1.pgdg90+1_amd64.deb \
+              /tmp/pgdebs/libpq5_10.10-1.pgdg90+1_amd64.deb \
+              /tmp/pgdebs/libpq-dev_10.10-1.pgdg90+1_amd64.deb
 RUN rm -r /tmp/pgdebs
 
 RUN ["chmod", "+x", "/neo4j-fdw/source/scripts/docker/postgres/init.sh"]

--- a/scripts/faketime.sh
+++ b/scripts/faketime.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1
+export FAKETIME_DONT_RESET=1
+export FAKETIME="@2019-07-14 17:30:00"
+


### PR DESCRIPTION
Changes to enable test-suite to complete successfully, and enable fresh release to be made.
Most changes for the fdw-pg image:
* Replace generic postgres:10 docker image with last specific version using python2.7
* Fetch and install corresponding postgresql-server-dev-10, postgresql-plpython-10 packages plus dependencies libpq5, and libpq-dev from postgresql.org archives
* Install libfaketime, and apply settings which will import and apply only when postgres is doing first-time initialisation. (Need a summer date, so that PST/PDT is UTC-7, per the expected outputs for pg_regress)

Small changes for the fdw-neo4j image:
* Use vanilla 'su', given loss of 'su-exec' now Neo4J no-longer uses Alpine Linux