### PR TITLE
Switch to automatic TLS setup by the driver

### DIFF
--- a/neo4jPg/neo4jPGFunction.py
+++ b/neo4jPg/neo4jPGFunction.py
@@ -15,7 +15,7 @@ def cypher(plpy, query, params, url, dbname, login, password):
     """
         Make cypher query and return JSON result
     """
-    driver = GraphDatabase.driver( url, auth=(login, password), encrypted=False)
+    driver = GraphDatabase.driver(url, auth=(login, password))
 
     # Execute & retrieve neo4j data
     if driver.supports_multi_db():


### PR DESCRIPTION
enables `neo4j+s`, `neo4j+ssc`, `bolt+s` and `bolt+ssc` connection schemas and neo4j aura as a result. Old version resulted in conflicts between `encrypted=False` when attempting to use a secure connection schema.